### PR TITLE
Added docker compose support with Azurite and Seq services

### DIFF
--- a/AzureBlobStorage.Test/AzureBlobStorage.Test.csproj
+++ b/AzureBlobStorage.Test/AzureBlobStorage.Test.csproj
@@ -8,10 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/AzureBlobStorage.sln
+++ b/AzureBlobStorage.sln
@@ -9,6 +9,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureBlobStorage.Test", "Az
 EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{9DCFE125-6311-45BF-9B89-B5B808C6C52F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BA6D3AAA-6653-408B-B5B4-DEA84345C3D1}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/AzureBlobStorage.sln
+++ b/AzureBlobStorage.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureBlobStorage.WebApi", "AzureBlobStorageWebApi\AzureBlobStorage.WebApi.csproj", "{F284D2E3-D02D-45BF-BF06-444EC236BCB3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureBlobStorage.Test", "AzureBlobStorage.Test\AzureBlobStorage.Test.csproj", "{BDF25E77-8A55-4449-80EE-06E5866530DC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureBlobStorage.Test", "AzureBlobStorage.Test\AzureBlobStorage.Test.csproj", "{BDF25E77-8A55-4449-80EE-06E5866530DC}"
+EndProject
+Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{9DCFE125-6311-45BF-9B89-B5B808C6C52F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{BDF25E77-8A55-4449-80EE-06E5866530DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BDF25E77-8A55-4449-80EE-06E5866530DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BDF25E77-8A55-4449-80EE-06E5866530DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DCFE125-6311-45BF-9B89-B5B808C6C52F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DCFE125-6311-45BF-9B89-B5B808C6C52F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DCFE125-6311-45BF-9B89-B5B808C6C52F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DCFE125-6311-45BF-9B89-B5B808C6C52F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AzureBlobStorageWebApi/AzureBlobStorage.WebApi.csproj
+++ b/AzureBlobStorageWebApi/AzureBlobStorage.WebApi.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/AzureBlobStorageWebApi/AzureBlobStorage.WebApi.csproj
+++ b/AzureBlobStorageWebApi/AzureBlobStorage.WebApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>1313ff8d-1a39-40f2-97b9-387802b0d481</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AzureBlobStorageWebApi/AzureBlobStorage.WebApi.csproj
+++ b/AzureBlobStorageWebApi/AzureBlobStorage.WebApi.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.11.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 
 </Project>

--- a/AzureBlobStorageWebApi/Program.cs
+++ b/AzureBlobStorageWebApi/Program.cs
@@ -14,6 +14,7 @@ try
     builder.Host.UseSerilog((_, config) =>
     {
         config.WriteTo.Console()
+        .WriteTo.Seq(serverUrl: "http://seq:5341")
         .ReadFrom.Configuration(builder.Configuration);
     });
 

--- a/AzureBlobStorageWebApi/Repository/AzureStorage.cs
+++ b/AzureBlobStorageWebApi/Repository/AzureStorage.cs
@@ -116,9 +116,14 @@ namespace AzureBlobStorage.WebApi.Repository
             // Create new upload response object that we can return to the requesting method
             BlobResponseDto response = new();
 
+
+
             // Get a reference to a container named in appsettings.json and then create it
             BlobContainerClient container = new BlobContainerClient(_storageConnectionString, _storageContainerName);
-            //await container.CreateAsync();
+
+            // Create the container if it does not exist
+            await container.CreateIfNotExistsAsync();
+
             try
             {
                 // Get a reference to the blob just uploaded from the API in a container from configuration settings

--- a/AzureBlobStorageWebApi/appsettings.json
+++ b/AzureBlobStorageWebApi/appsettings.json
@@ -6,6 +6,6 @@
     }
   },
   "AllowedHosts": "*",
-  "BlobConnectionString": "DefaultEndpointsProtocol=https;AccountName=webapiazurestorage;AccountKey=xFeeUIUwj7zmxBUFuPD2FNnXVS9EsKujwMniZNXHV/TqEmv4mHQ1Qxrr9+00eUCsJjbtdXJH0soJTzsiYvg/ag==;EndpointSuffix=core.windows.net",
-  "BlobContainerName": "files-container"
+  "BlobConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://host.docker.internal:10000/devstoreaccount1;QueueEndpoint=http://host.docker.internal:10001/devstoreaccount1;TableEndpoint=http://host.docker.internal:10002/devstoreaccount1;",
+  "BlobContainerName": "files"
 }

--- a/README.md
+++ b/README.md
@@ -3,6 +3,25 @@
 
 You can find the fill guide on how this API was made with detailed instructions for configuration of Azure + API here: [How to use Azure Blob Storage in an ASP.NET Core Web API to list, upload, download, and delete files](https://christian-schou.dk/how-to-use-azure-blob-storage-with-asp-net-core/).
 
+## Development Setup (Docker)
+
+1. Clone project to local machine
+2. Open solution file 
+3. Choose to start the `docker-compose` launch settings
+
+N'joy :-)
+
+The above steps will start [Azurite storage emulator](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=visual-studio), 
+[Seq](https://datalust.co/seq) log server and the API. The services will be started by
+the definitions in the docker-compose.yml file
+
+All Docker container logs will also be sent to the Seq log server.
+
+To see all logs, open http://localhost:5341/
+
+Running Docker requires that you have installed [Docker Desktop for Windows](https://docs.docker.com/desktop/install/windows-install/).
+
+
 ## Development Setup
 
 Azure:

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" Sdk="Microsoft.Docker.Sdk">
+  <PropertyGroup Label="Globals">
+    <ProjectVersion>2.1</ProjectVersion>
+    <DockerTargetOS>Linux</DockerTargetOS>
+    <ProjectGuid>9dcfe125-6311-45bf-9b89-b5b808c6c52f</ProjectGuid>
+    <DockerLaunchAction>LaunchBrowser</DockerLaunchAction>
+    <DockerServiceUrl>{Scheme}://localhost:{ServicePort}/swagger</DockerServiceUrl>
+    <DockerServiceName>azureblobstorage.webapi</DockerServiceName>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="docker-compose.override.yml">
+      <DependentUpon>docker-compose.yml</DependentUpon>
+    </None>
+    <None Include="docker-compose.yml" />
+    <None Include=".dockerignore" />
+  </ItemGroup>
+</Project>

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,13 @@
+version: '3.4'
+
+services:
+  azureblobstorage.webapi:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_URLS=https://+:443;http://+:80
+    ports:
+      - "80"
+      - "443"
+    volumes:
+      - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
+      - ${APPDATA}/ASP.NET/Https:/root/.aspnet/https:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3.4'
+
+x-logging:
+      &default-logging
+      driver: gelf
+      options:
+        gelf-address: udp://0.0.0.0:12201/udp
+
+
+services:
+  seq:
+    image: datalust/seq
+    ports:
+      - 5341:80
+    environment:
+      -  ACCEPT_EULA=Y
+    volumes:
+      - seq_data:/data
+
+  seq-input-gelf:
+    image: datalust/seq-input-gelf:latest
+    depends_on:
+      - seq
+    ports:
+      - 12201:12201/udp
+    environment:
+      - SEQ_ADDRESS=http://seq:5341
+      - GELF_ENABLE_DIAGNOSTICS=False
+
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    ports:
+        - 10000:10000
+        - 10001:10001
+        - 10002:10002
+    volumes:
+        - azurite_data:/data
+    logging: *default-logging
+
+  azureblobstorage.webapi:
+    image: ${DOCKER_REGISTRY-}azureblobstoragewebapi
+    depends_on:
+        - seq
+        - azurite
+
+    build:
+      context: .
+      dockerfile: AzureBlobStorageWebApi/Dockerfile
+
+volumes:
+  azurite_data:
+  seq_data:

--- a/launchSettings.json
+++ b/launchSettings.json
@@ -1,0 +1,17 @@
+{
+  "profiles": {
+    "Docker Compose": {
+      "commandName": "DockerCompose",
+      "commandVersion": "1.0",
+      "composeLaunchAction": "LaunchBrowser",
+      "composeLaunchServiceName": "azureblobstorage.webapi",
+      "composeLaunchUrl": "{Scheme}://localhost:{ServicePort}/swagger",
+      "serviceActions": {
+        "azureblobstorage.webapi": "StartDebugging",
+        "azurite": "StartWithoutDebugging",
+        "seq": "StartWithoutDebugging",
+        "seq-input-gelf": "StartWithoutDebugging"
+      }
+    }
+  }
+}


### PR DESCRIPTION
THanks for the nice writeup of how to use Storage Blobs :-)

To make this even easier I added a docker-compose.yml file that works with Visual Studio (tested with 2022 ) and Docker to enable local development. No need to create Azure Storage accounts or install the Seq server.

All is defined in the docker-compose file and can be launche using F5 within Visual Studio.

I also added CreateIfNotExists to create the container if it does not exist (when using the loal emulator)